### PR TITLE
Create distinct defaults for both dev compose file and prod compose file

### DIFF
--- a/.dockerenv_prod
+++ b/.dockerenv_prod
@@ -1,3 +1,3 @@
-RAILS_ENV=development
+RAILS_ENV=production
 KOSA2_DATABASE_HOST=db
 POSTGRES_USER=kosa2

--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - /mnt/efs/volumes/db:/var/lib/postgresql/data
     env_file:
-      - .dockerenv
+      - .dockerenv_prod
       - .env.local_password
   web:
     build:
@@ -31,7 +31,7 @@ services:
     ports:
       - "3000:3000"
     env_file:
-      - .dockerenv
+      - .dockerenv_prod
       - .env.local_password
       - /home/ec2-user/.kosa/kosa-rails.dockerenv
     environment:


### PR DESCRIPTION
rails env config is controlled via .dockerenv, which is more of a convention that a necessary condition. This file is then referenced in docker-compose for reference.

Adding .dockerenv_prod for prod variables